### PR TITLE
Change contributor list format - append hyperlinked username

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ resource](https://help.github.com/articles/good-resources-for-learning-git-and-g
 
 Your entry should maintain alphabetic order and it should be in the format
 `* your name`. This file is written in the [Markdown format](https://guides.github.com/features/mastering-markdown/)
-and the lines starting with `*` are automatically rendered as Bullet entries.
+and the lines starting with `*` are automatically rendered as bullet points.
 
-* Abinash Meher
-* Aditya Narayan
-* Arna Ghosh
-* Harsh Gupta
-* Krishna Bagadia
-* Nevin Valsaraj
+* Abinash Meher [abinashmeher999](http://github.com/abinashmeher999)
+* Aditya Narayan [narayanaditya95](http://github.com/narayanaditya95)
+* Arna Ghosh [arnaghosh](http://github.com/arnaghosh)
+* Harsh Gupta [hargup](http://github.com/hargup)
+* Krishna Bagadia [krishna95](http://github.com/krishna95)
+* Nevin Valsaraj [routeaccess](http://github.com/routeaccess)


### PR DESCRIPTION
Modify format of contributor list to append GitHub username to every
contributor's name. Each username is hyperlinked to the user's
profile page.

Signed-off-by: Nevin Valsaraj <nevin.valsaraj32@gmail.com>