### PR TITLE
Remove alphaend from the end of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ Lines starting with `*` are automatically rendered as bullet points and phrases 
 * Utkarsh Gupta [khalibartan](https://github.com/khalibartan)
 * Utkarsh Tyagi [utki96](https://github.com/utki96)
 * Vasudha Todi [todivasudha](https://github.com/todivasudha)
+
 <!--ALPHAEND-->


### PR DESCRIPTION
- End marker is shown when the README is rendered on GitHub.
- For some reason, when on the line after the bullet list, it is not recognised as an HTML template.
- [This version](https://github.com/icyflame/git-sandbox/tree/fix-readme#readme) doesn't show the end marker.